### PR TITLE
chore: add Enablement & Standards team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# info about codeowners - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Enablement & Standards team owns this repository
+*        @livingdocsIO/enablement-standards
+
+# CODEOWNERS prevent renovate automerge since it will automatically ask for review
+# See documentation for more details: https://docs.renovatebot.com/automerge-configuration/
+# Solution: make files used by renovate owned by everyone
+/package.json
+/package-lock.json


### PR DESCRIPTION
## What

Add a `.github/CODEOWNERS` file assigning the **@livingdocsIO/enablement-standards** team as owner of this repository.

## Why

This tooling repo had no CODEOWNERS. The Enablement & Standards team maintains it, so they should be the default reviewers.

## Structure

Modeled on the MSP CODEOWNERS convention:
- The team owns everything via `*`.
- `/package.json` and `/package-lock.json` are intentionally left **without an owner** so [Renovate automerge](https://docs.renovatebot.com/automerge-configuration/) isn't blocked by a required CODEOWNERS review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)