### PR TITLE
Log clear, actionable messages on failed GitHub API requests

### DIFF
--- a/git/create-branch.js
+++ b/git/create-branch.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference
 module.exports = async ({owner, repo, token, ref, sha, debug}) => {
@@ -22,11 +23,11 @@ module.exports = async ({owner, repo, token, ref, sha, debug}) => {
     }
     return {sha: data.object.sha}
   } catch (error) {
-    console.error(error.message)
-    console.error(error?.response?.data)
-    console.error(
-      'github-create-downstream-release-branch.create-branch: create release branch failed'
-    )
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.create-branch',
+      owner,
+      repo
+    })
     if (error?.response?.status === 422) {
       console.error(
         `Hint: You need to check "Do not require status checks on creation" for a release branch on the GitHub branch protection rules.`

--- a/git/create-pull-request.js
+++ b/git/create-pull-request.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request
 module.exports = async ({owner, repo, token, title, head, base, body, debug}) => {
@@ -20,8 +21,11 @@ module.exports = async ({owner, repo, token, title, head, base, body, debug}) =>
     if (debug) console.log('github-create-downstream-release-branch.create-pull-request()', data)
     return data
   } catch (error) {
-    console.error(error)
-    console.error('github-create-downstream-release-branch.create-pull-request: failed')
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.create-pull-request',
+      owner,
+      repo
+    })
     throw error
   }
 }

--- a/git/get-content.js
+++ b/git/get-content.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
 //
@@ -23,8 +24,11 @@ module.exports = async ({owner, repo, token, path, debug}) => {
     }
     return data
   } catch (error) {
-    console.error(error)
-    console.error('github-create-downstream-release-branch.get-content: failed')
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.get-content',
+      owner,
+      repo
+    })
     throw error
   }
 }

--- a/git/get-tag.js
+++ b/git/get-tag.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
 //
@@ -36,8 +37,11 @@ module.exports = async ({owner, repo, token, tag, debug}) => {
       sha: data.object.sha
     }
   } catch (error) {
-    console.error(error)
-    console.error('github-create-downstream-release-branch.get-tag: failed')
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.get-tag',
+      owner,
+      repo
+    })
     throw error
   }
 }

--- a/git/get-tags.js
+++ b/git/get-tags.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/reference/repos#list-repository-tags
 // https://api.github.com/repos/livingdocsio/livingdocs-server/tags?access_token=1234
@@ -31,8 +32,11 @@ module.exports = async ({owner, repo, token, page = 1, perPage = 10, debug}) => 
     }
     return data
   } catch (error) {
-    console.error(error)
-    console.error('github-create-downstream-release-branch.get-tags: failed')
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.get-tags',
+      owner,
+      repo
+    })
     throw error
   }
 }

--- a/git/log-github-error.js
+++ b/git/log-github-error.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Logs a clear, actionable message for a failed GitHub API request. The caller
+// is still responsible for rethrowing the original error.
+//
+// We intentionally do NOT log the raw axios error object: it carries the
+// request config including the Authorization header, i.e. it would leak the
+// --gh-token into the output.
+module.exports = function logGithubError(error, {context, owner, repo}) {
+  const status = error.response?.status
+  const data = error.response?.data
+
+  console.error(`${context} failed: ${error.message}`)
+  if (data) console.error(data)
+
+  if (status === 401) {
+    console.error('Hint: 401 Unauthorized - the --gh-token is missing, malformed or expired.')
+  } else if (status === 403) {
+    console.error('Hint: 403 Forbidden - the --gh-token lacks scope, or a rate limit was hit.')
+  } else if (status === 404) {
+    console.error(
+      `Hint: 404 Not Found for "${owner}/${repo}". Either the repository does not exist, or the ` +
+        '--gh-token cannot access it. GitHub returns 404 (not 403) for private repos a token ' +
+        'cannot see, so check --owner/--repo and that the token has access to that repository.'
+    )
+  }
+}

--- a/git/update-content.js
+++ b/git/update-content.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const logGithubError = require('./log-github-error')
 
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents
 //
@@ -21,8 +22,11 @@ module.exports = async ({owner, repo, token, path, message, content, sha, branch
     )
     return data
   } catch (error) {
-    console.error(error)
-    console.error('github-create-downstream-release-branch.update-content: failed')
+    logGithubError(error, {
+      context: 'github-create-downstream-release-branch.update-content',
+      owner,
+      repo
+    })
     throw error
   }
 }


### PR DESCRIPTION
Relations:

- Issue: n/a
- Related PR's: livingdocsIO/downstream-sdk#148 — preflight access check so the `create-release-branch.sh` wrapper fails fast when this (private) repo is inaccessible

# Motivation

The `git/*` request helpers logged the raw axios error object on failure. That output is noisy and, worse, includes the request config with the `Authorization` header — leaking the `--gh-token`. It also gave no hint about *why* a call failed (e.g. a 404 from a missing repo or a token without access).

# Changelog

Add a shared `git/log-github-error.js` helper that prints a concise message plus a status-specific hint (401 / 403 / 404) and never dumps the raw error. Wire it into all six request helpers; `create-branch`'s existing 422 branch-protection hint is preserved.
