### PR TITLE
chore(renovate): switch to renovate-config-public preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>livingdocsIO/customer-solutions:renovate-msp-default.json5"],
-  "ignoreDeps": [],
-  "baseBranches": ["main"],
-  "packageRules": []
+  "extends": ["local>livingdocsIO/renovate-config-public"]
 }


### PR DESCRIPTION
## What

Switch the Renovate preset from the MSP customer-downstream config to the public config:

```diff
- "extends": ["local>livingdocsIO/customer-solutions:renovate-msp-default.json5"]
+ "extends": ["local>livingdocsIO/renovate-config-public"]
```

Also drops the now-unnecessary `ignoreDeps`, `baseBranches`, and empty `packageRules` (the preset already handles `main` automerge for patches/digests/devDeps).

## Why

This repo is a **public, `main`-only npm CLI tool** with only **public** dependencies (`axios`, `lodash`, `semver`, `yargs` + eslint dev deps). It is **not** an MSP customer downstream:

- `renovate-msp-default.json5` is designed for downstreams that track upstream `@livingdocs/server`/`editor` across `release-*` branches via `followTag` — none of which applies here.
- `renovate-config-public` is the preset used by the org's other public/library repos (`srcissors`, `microschema`, `secure-password`, …) and is the correct category for this repo.
- The internal `renovate-config` preset would be overkill: it injects an `NPM_TOKEN` host rule and `@livingdocs/*` special-casing that this repo does not need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
